### PR TITLE
Fix color-list overlapping options list

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -189,6 +189,7 @@ header {
 
   .options {
     padding: 1rem;
+    flex: 1 0;
   }
 
   .color-list {


### PR DESCRIPTION
A quick fix for color-list overlapping other options: variance and cell-size.
".options" class just needs to have flex-shrink: 0, or flex: 1 0.

The bug can be reproduced in Chrome on OS X, and Ubuntu.

Images of UI before and after the fix:
http://s22.postimg.org/acn22f8rl/trgl_default.png
http://s22.postimg.org/6hjnzuplt/trgl_fixed.png